### PR TITLE
Add course formats links and "for individuals whom slides"

### DIFF
--- a/01-intro.Rmd
+++ b/01-intro.Rmd
@@ -11,7 +11,7 @@ ottrpal::set_knitr_image_path()
 ```
 
 
-# Introduction 
+# Introduction
 
 ```{r, fig.alt="Title image: Leadership for Cancer Informatics Research", out.width = "100%", echo = FALSE}
 ottrpal::include_slide("https://docs.google.com/presentation/d/1OU5qeRgN_fojGbcyu2qEdwlcKpDO6BveWtYW_u1Hqd4/export/png?id=1OU5qeRgN_fojGbcyu2qEdwlcKpDO6BveWtYW_u1Hqd4&pageid=gcf28d80132_0_418")
@@ -19,16 +19,26 @@ ottrpal::include_slide("https://docs.google.com/presentation/d/1OU5qeRgN_fojGbcy
 
 ## Motivation
 
-Informatics research often requires multidisciplinary teams. This requires more flexibility to communicate with team members with distinct backgrounds. Furthermore, team members often have different research and career goals. This can present unique challenges in making sure that everyone is on the same page and cohesively working together. 
+Informatics research often requires multidisciplinary teams. This requires more flexibility to communicate with team members with distinct backgrounds. Furthermore, team members often have different research and career goals. This can present unique challenges in making sure that everyone is on the same page and cohesively working together.
 
 
 ## Target audience
 
 The course is intended for researchers who lead research teams or collaborate with others to perform multidisciplinary work. We have especially aimed the material for those with **moderate to no computational experience** who may lead or collaborate with informatics experts. However this material is **also applicable to informatics experts working with others who have less computational experience.**
 
+```{r, fig.alt="For individuals whom: Are new to informatics but want to do more. Are informatics researchers who want to collaborate with experimental/wet bench researchers effectively. Want to support more diversity, equity, and inclusion practices in their research and management", out.width = "100%", echo = FALSE}
+ottrpal::include_slide("https://docs.google.com/presentation/d/1OU5qeRgN_fojGbcyu2qEdwlcKpDO6BveWtYW_u1Hqd4/edit#slide=id.g11ed88220f1_0_71")
+```
+
+## Topics covered:
+
+```{r, fig.alt="Concepts discussed in the Leadership for Cancer Informatics Research course: How to support multidisciplinary mentees, Promote and support an inclusive and diverse team, Collaborate with multidisciplinary teams, Support more health equity in research, Identify good informatics questions, Tools and workflows to support research management, Avoid informatics project pitfalls", out.width = "100%", echo = FALSE}
+ottrpal::include_slide("https://docs.google.com/presentation/d/1OU5qeRgN_fojGbcyu2qEdwlcKpDO6BveWtYW_u1Hqd4/edit#slide=id.g11ed88220f1_0_91")
+```
+
 ## Curriculum
 
-We will provide you with an awareness for the **specific challenges** that your informatics collaborators, employees, and mentees might face, as well as ways to mitigate these challenges. By creating a better work environment for your informatics research team, you will ultimately improve the potential impact of your work. 
+We will provide you with an awareness for the **specific challenges** that your informatics collaborators, employees, and mentees might face, as well as ways to mitigate these challenges. By creating a better work environment for your informatics research team, you will ultimately improve the potential impact of your work.
 
 We will also discuss the major **pitfalls of informatics research** and discuss best practices for performing informatics research correctly and well, so that you can get the most out of your informatics projects.
 
@@ -38,7 +48,7 @@ ottrpal::include_slide("https://docs.google.com/presentation/d/1OU5qeRgN_fojGbcy
 
 ## Informatics teams challenges
 
-Informatics work presents unique challenges due to the fact that it requires multidisciplinary teams. 
+Informatics work presents unique challenges due to the fact that it requires multidisciplinary teams.
 
 According to a recent article about this subject:
 
@@ -66,7 +76,7 @@ Next, we have Charlie. He is new to informatics research and could learn a bit a
 ottrpal::include_slide("https://docs.google.com/presentation/d/1OU5qeRgN_fojGbcyu2qEdwlcKpDO6BveWtYW_u1Hqd4/edit#slide=id.gc53d3d234f_0_103")
 ```
 
-Now we have our informaticists. First is Jack, who is often forgotten and misunderstood by his lab leader. His lab leader does not really know what he does, how long his work takes, or how to support Jack and his career goals. This is unfortunately impeding Jack from achieving the career that he could have and from producing the good work that he is capable of. 
+Now we have our informaticists. First is Jack, who is often forgotten and misunderstood by his lab leader. His lab leader does not really know what he does, how long his work takes, or how to support Jack and his career goals. This is unfortunately impeding Jack from achieving the career that he could have and from producing the good work that he is capable of.
 
 
 ```{r, fig.alt=" This is Jack, the only and lonely informaticist. He feels very misunderstood", out.width = "100%", echo = FALSE}
@@ -88,7 +98,7 @@ ottrpal::include_slide("https://docs.google.com/presentation/d/1OU5qeRgN_fojGbcy
 ```
 
 
-Finally we have Harry, the helpful collaborator. He clearly communicates with his collaborators and is well organized! He teaches is collaborators about informatics and they teach him about their knowledge.  He and his collaborators have very productive projects. 
+Finally we have Harry, the helpful collaborator. He clearly communicates with his collaborators and is well organized! He teaches is collaborators about informatics and they teach him about their knowledge.  He and his collaborators have very productive projects.
 
 
 ```{r, fig.alt=" This is Harry, the helpful collaborator. He helps you and you help him!", out.width = "100%", echo = FALSE}
@@ -98,4 +108,3 @@ ottrpal::include_slide("https://docs.google.com/presentation/d/1OU5qeRgN_fojGbcy
 We will now describe some guidelines for how to be an effective leader, collaborator, and mentor on informatics projects so that you can be more like Sally with mentees and employees like Hilda and collaborators like Harry.
 
 Keep in mind that while our cartoons often exaggerate situations to make them more comical, more subtle situations can still be very detrimental to your research teammates.  
-

--- a/index.Rmd
+++ b/index.Rmd
@@ -1,4 +1,4 @@
---- 
+---
 title: "Leadership for Cancer Informatics Research"
 date: "`r Sys.Date()`"
 site: bookdown::bookdown_site
@@ -22,4 +22,11 @@ knitr::write_bib(c(
 
 This course is part of a series of courses for the [Informatics Technology for Cancer Research (ITCR)](https://itcr.cancer.gov/) called the Informatics Technology for Cancer Research Education Resource. This material was created by the ITCR Training Network (ITN)  which is a collaborative effort of researchers around the United States to support cancer informatics and data science training through resources, technology, and events. This initiative is funded by the following grant:  [National Cancer Institute (NCI)](https://www.cancer.gov/)  UE5 CA254170. Our courses feature tools developed by ITCR Investigators and make it easier for principal investigators, scientists, and analysts to integrate cancer informatics into their workflows. Please see our website at [www.itcrtraining.org](www.itcrtraining.org) for more information. Except where otherwise indicated, the contents of this course are available for use under the Creative Commons Attribution 4.0 license. You are free to adapt and share the work, but you must give appropriate credit, provide a link to the license, and indicate if changes were made. Sample attribution: Leadership for Cancer Informatics Research by Johns Hopkins Data Science Lab (CC-BY 4.0). You can download the illustrations by clicking [here](https://docs.google.com/presentation/d/1OU5qeRgN_fojGbcyu2qEdwlcKpDO6BveWtYW_u1Hqd4/edit?usp=sharing).
 
+## Available course formats
 
+This course is available in multiple formats which allows you to take it in the way that best suites your needs. You can take it for certificate which can be for free or fee.
+
+- The material for this course can be viewed without login requirement on this [Bookdown website](https://jhudatascience.org/Informatics_Research_Leadership/). This format might be most appropriate for you if you rely on screen-reader technology.
+- This course can be taken for [free certification through Leanpub](https://leanpub.com/universities/courses/jhu/cancer-informatics-for-research-leaders).
+- This course can be taken on [Coursera for certification here](https://www.coursera.org/learn/leadership-for-cancer-informatics-research) (but it is not available for free on Coursera).
+- Our courses are open source, you can find the [source material for this course on GitHub](https://github.com/jhudsl/Informatics_Research_Leadership).

--- a/resources/dictionary.txt
+++ b/resources/dictionary.txt
@@ -1,3 +1,4 @@
+Bookdown
 Evernote
 HIPPA
 integrations
@@ -27,6 +28,7 @@ Broman
 cBioPortal
 cells’
 CFCs
+Coursera
 chancroid
 citable
 colorectal
@@ -72,6 +74,7 @@ JupyterLab
 Kha'po
 Kimberlé
 knitr
+Leanpub
 Lacks’s
 Laguna
 Latinx


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?

These adds are a part of a series across all current ITCR courses are two fold: 

1) Add course format links so people are aware of the other ways to take the course no matter where they land. 
2) Make it clear up front whom the course is for and what topics are covered by adding in our standard slide cards. 